### PR TITLE
Update controller and service to use YoutubeTranscriptApi

### DIFF
--- a/controllers/transcript_controller.py
+++ b/controllers/transcript_controller.py
@@ -4,19 +4,33 @@ from services.transcript_service import TranscriptService
 transcript_bp = Blueprint("transcript", __name__, url_prefix="/transcript")
 transcript_service = TranscriptService()
 
-@transcript_bp.route("/<video_id>", methods=["GET"])
-def get_transcript_fallback(video_id):
-    language = request.args.get("lang", "en")
-    subtitle_format = request.args.get("format", "vtt")  # 'srt' or 'vtt'
+# @transcript_bp.route("/<video_id>", methods=["GET"])
+# def get_transcript_fallback(video_id):
+#     language = request.args.get("lang", "en")
+#     subtitle_format = request.args.get("format", "vtt")  # 'srt' or 'vtt'
 
+#     try:
+#         transcripts = transcript_service.get_transcript_with_ytdlp(video_id, language, subtitle_format)
+#         return jsonify({
+#             "video_id": video_id,
+#             "language": language,
+#             "transcript": transcripts["transcript"],
+#             "transcript_with_timestamps": transcripts["transcript_with_timestamps"],
+#             "metadata": transcripts["metadata"]
+#         })
+#     except ValueError as e:
+#         return jsonify({"error": str(e)}), 400
+
+@transcript_bp.route('/<video_id>', methods=['GET'])
+def get_transcript_with_youtube_transcript_api(video_id):
+    language = request.args.get("lang", "en")
     try:
-        transcripts = transcript_service.get_transcript_with_ytdlp(video_id, language, subtitle_format)
+        transcripts = transcript_service.get_transcript_with_youtube_transcript_api(video_id, language)
         return jsonify({
             "video_id": video_id,
             "language": language,
             "transcript": transcripts["transcript"],
             "transcript_with_timestamps": transcripts["transcript_with_timestamps"],
-            "metadata": transcripts["metadata"]
         })
     except ValueError as e:
         return jsonify({"error": str(e)}), 400

--- a/services/transcript_service.py
+++ b/services/transcript_service.py
@@ -1,7 +1,32 @@
 from yt_dlp import YoutubeDL
+from youtube_transcript_api import YouTubeTranscriptApi
 import os
 
 class TranscriptService:
+
+    def get_transcript_with_youtube_transcript_api(self, video_id: str, language: str = "en") -> dict:
+        """
+        Use the YouTube Transcript API to get the transcript of a video. Return the cleaned transcript as string,
+        and the raw transcript as a list of dictionaries with timestamps, duration, and text.
+
+        The method does not use the yt-dlp library, but the YouTube Transcript API. Correspondingly, the method does not have access to the video metadata.
+        """
+        try:
+            api = YouTubeTranscriptApi()
+            transcript = api.fetch(video_id, languages=[language])
+            raw_transcript = transcript.to_raw_data()
+
+            cleaned_transcript = '\n'.join([item['text'] for item in raw_transcript])  # `cleaned_transcript` looks like "Line1\nLine2..."
+
+            return {
+                'video_id': video_id, 
+                'language': language, 
+                'transcript': cleaned_transcript,
+                'transcript_with_timestamps': raw_transcript,
+            }
+            
+        except Exception as e:
+            raise ValueError(f"youtube_transcript_api error: {str(e)}")
 
     def get_transcript_with_ytdlp(self, video_id: str, language: str = "en", subtitle_format: str = "vtt") -> dict:
 


### PR DESCRIPTION
* Added a method, `get_transcript_with_youtube_transcript_api` to the Transcript Service class to use YoutubeTranscriptAPI
*  modified the controller logic to use the newly defined method.
* Transcript with timestamps stored as a list of dictionaries `{'text': ... , 'start': ..., 'duration': ...}`
* Raw transcript text extracted from list of dictionaries.

By using YoutubeTranscriptApi, the method no longer has access to the video metadata, and this will have to be implemented at another time, if so needed.  